### PR TITLE
Add Microsoft EdgeML

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ A curated list of edge devices for AI applications.
 - [Tensorflow Lite](https://www.tensorflow.org/lite)
 - [TinyDNN](https://github.com/tiny-dnn/tiny-dnn)
 - [uTensor](https://github.com/uTensor/uTensor)
+- [EdgeML](https://github.com/Microsoft/EdgeML)
 
 
 ## Contribute


### PR DESCRIPTION
Add Microsoft EdgeML under software. More research than production ready, but quite interesting for smaller devices (e.g. 16kB RAM) than uTensor or TensorFlow Lite, and some more classical machine learning algorithms as well.

Add new item or section.

- [x] Update table of contents
- [x] Tell which section/ item added or changed.
