### PR TITLE
Add Legend of Elya — LLM inference on Nintendo 64 (MIPS R4300i)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,10 @@ A curated list of edge devices for AI applications.
 - [Sipeed MAIX](https://www.indiegogo.com/projects/sipeed-maix-the-world-first-risc-v-64-ai-module#/)
 - TI Vision AcclerationPac
 
+### Retro Hardware AI Inference
+
+- [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) - World's first LLM on Nintendo 64. 819K-parameter nano-GPT transformer running live inference on the MIPS R4300i CPU (93.75 MHz, 4 MB RAM) at 60 tok/s. Demonstrates AI inference on the most constrained hardware possible — a 1996 game console. Uses RSP vector unit for matrix multiplication.
+
 ### Software Libraries
 
 - [Tensorflow Lite](https://www.tensorflow.org/lite)


### PR DESCRIPTION
## Summary

Adds [Legend of Elya](https://github.com/Scottcjn/legend-of-elya-n64) under a new "Retro Hardware AI Inference" subsection.

This is the most extreme edge AI deployment I'm aware of — an 819K-parameter nano-GPT transformer running live inference on the Nintendo 64's MIPS R4300i CPU at 93.75 MHz with just 4 MB of RAM.

- **60 tokens/second** inference speed
- Uses the N64's RSP vector unit for matrix multiplication
- Produces a playable Zelda-style dungeon crawler with AI NPCs
- Full source code and .z64 ROM available

Demonstrates that neural network inference is possible even on 1996 console hardware, which represents an interesting extreme of the edge AI spectrum.